### PR TITLE
add top-level redirects to a few frequently posted links

### DIFF
--- a/cfp.html
+++ b/cfp.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to EventBrite</title>
+<meta http-equiv="refresh" content="0; URL=https://www.papercall.io/nescala-2020">
+<link rel="canonical" href="https://www.papercall.io/nescala-2020">

--- a/cfp.html
+++ b/cfp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to EventBrite</title>
+<title>Redirecting to papercall.io</title>
 <meta http-equiv="refresh" content="0; URL=https://www.papercall.io/nescala-2020">
 <link rel="canonical" href="https://www.papercall.io/nescala-2020">

--- a/gmaps.html
+++ b/gmaps.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to EventBrite</title>
+<title>Redirecting to Google Maps</title>
 <meta http-equiv="refresh" content="0; URL=https://goo.gl/maps/CuQD8Sdr13j4FYMx8">
 <link rel="canonical" href="https://goo.gl/maps/CuQD8Sdr13j4FYMx8">

--- a/gmaps.html
+++ b/gmaps.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to EventBrite</title>
+<meta http-equiv="refresh" content="0; URL=https://goo.gl/maps/CuQD8Sdr13j4FYMx8">
+<link rel="canonical" href="https://goo.gl/maps/CuQD8Sdr13j4FYMx8">

--- a/tix.html
+++ b/tix.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to EventBrite</title>
+<meta http-equiv="refresh" content="0; URL=https://www.eventbrite.com/e/northeast-scala-symposium-typelevel-summit-2020-tickets-92788556069">
+<link rel="canonical" href="https://www.eventbrite.com/e/northeast-scala-symposium-typelevel-summit-2020-tickets-92788556069">

--- a/venue.html
+++ b/venue.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to EventBrite</title>
+<title>Redirecting to 26 Bridge</title>
 <meta http-equiv="refresh" content="0; URL=https://www.26bridge.com/">
 <link rel="canonical" href="https://www.26bridge.com/">

--- a/venue.html
+++ b/venue.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to EventBrite</title>
+<meta http-equiv="refresh" content="0; URL=https://www.26bridge.com/">
+<link rel="canonical" href="https://www.26bridge.com/">


### PR DESCRIPTION
- **/tix** → https://www.eventbrite.com/e/northeast-scala-symposium-typelevel-summit-2020-tickets-92788556069
- **/cfp** → https://www.papercall.io/nescala-2020 (soon to be less relevant but 🤷🏼‍♂️)
- **/venue** → https://www.26bridge.com/
- **/gmap** → https://goo.gl/maps/CuQD8Sdr13j4FYMx8 

may be useful to just do `https://nescala.io/XXX` instead of some of the `https://bit.ly/nescala-2020-XXX` I've been sending around a lot