### PR TITLE
Remove font-awesome link

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,4 +1,3 @@
-@import url("font-awesome.min.css");
 @import url("https://fonts.googleapis.com/css?family=Lato:400,400italic,700,700italic|Source+Code+Pro:400");
 
 /*


### PR DESCRIPTION
We needed a newer version of FA, to get the Mastodon logo. The quickest and easiest way to do that was to switch to a FA "kit", hosted on their CDN. So let's remove the reference that was causing 404s in the background.

We can (and probably should) switch to a self-hosted kit in the near future, so this may switch back, but one problem at a time.